### PR TITLE
state & proxy: various fixes

### DIFF
--- a/packtivity/backendutils.py
+++ b/packtivity/backendutils.py
@@ -4,7 +4,8 @@ import yaml
 import packtivity.asyncbackends as asyncbackends
 import packtivity.syncbackends as syncbackends
 
-def proxy_from_json(jsondata, best_effort_backend = True):
+def proxy_from_json(jsondata, best_effort_backend = True, raise_on_unknown = False):
+    proxy, backend = None, None
     if jsondata['proxyname'] == 'CeleryProxy':
         from .asyncbackends import CeleryProxy
         proxy = CeleryProxy.fromJSON(jsondata)
@@ -25,6 +26,8 @@ def proxy_from_json(jsondata, best_effort_backend = True):
         proxyclass = getattr(module,proxyclass)
         proxy = proxyclass.fromJSON(jsondata)
         _, backend = backend_from_string('fromenv')
+    if not proxy and raise_on_unknown:
+        raise RuntimeError('unknown proxy type: %s', jsondata['proxyname'])
     if best_effort_backend:
         return proxy, backend
     return proxy

--- a/packtivity/statecontexts/__init__.py
+++ b/packtivity/statecontexts/__init__.py
@@ -8,8 +8,6 @@ def load_state(jsondata):
     if 'PACKTIVITY_STATEPROVIDER' in os.environ:
         module = importlib.import_module(os.environ['PACKTIVITY_STATEPROVIDER'])
         return module.load_state(jsondata)
-
-
     raise TypeError('unknown state type {}'.format(jsondata['state_type']))
 
 def load_provider(jsondata):
@@ -17,3 +15,7 @@ def load_provider(jsondata):
         return None
     if jsondata['state_provider_type'] == 'localfs_provider':
         return LocalFSProvider.fromJSON(jsondata)
+    if 'PACKTIVITY_STATEPROVIDER' in os.environ:
+        module = importlib.import_module(os.environ['PACKTIVITY_STATEPROVIDER'])
+        return module.load_provider(jsondata)
+    raise TypeError('unknown provider type {}'.format(jsondata['state_provider_type']))

--- a/packtivity/statecontexts/posixfs_context.py
+++ b/packtivity/statecontexts/posixfs_context.py
@@ -14,6 +14,11 @@ class LocalFSState(object):
     Local Filesyste State consisting of a number of readwrite and readonly directories
     '''
     def __init__(self,readwrite = None,readonly = None, dependencies = None, identifier = 'unidentified_state'):
+        try:
+            assert type(readwrite) in [list, type(None)]
+            assert type(readonly) in [list, type(None)]
+        except AssertionError:
+            raise TypeError('readwrite and readonly must be None or a list {} {}'.format(type(readwrite), type(readonly)))
         self._identifier = identifier
         self.readwrite = list(map(os.path.realpath,readwrite) if readwrite else  [])
         self.readonly  = list(map(os.path.realpath,readonly) if readonly else  [])
@@ -66,7 +71,7 @@ class LocalFSState(object):
         contextualizes string data by string interpolation.
         replaces '{workdir}' placeholder with first readwrite directory
         '''
-        try: 
+        try:
             workdir = self.readwrite[0]
             return data.format(workdir = workdir)
         except AttributeError:
@@ -146,7 +151,7 @@ class LocalFSProvider(object):
         newstate = LocalFSState(readwrite = new_readwrites, readonly = new_readonlies, identifier = new_identifier)
 
         if self.ensure:
-            newstate.ensure()        
+            newstate.ensure()
         return newstate
 
     def json(self):
@@ -160,5 +165,3 @@ class LocalFSProvider(object):
     @classmethod
     def fromJSON(cls,jsondata):
         return cls(LocalFSState.fromJSON(jsondata['base_state']), nest = jsondata['nest'], ensure = jsondata['ensure'])
-
-


### PR DESCRIPTION
* load state provider from env if fromenv, plugins need to define load_provider
* type check readwrite / readonly lists (common mistake to give just str of single path)
* generic load_proxy function for async proxies