### PR TITLE
celery backend: add switch to tweak disable sync in result.get()

### DIFF
--- a/packtivity/asyncbackends.py
+++ b/packtivity/asyncbackends.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 import os
 import logging
+import yaml
 
 from .syncbackends import run_packtivity
 from .syncbackends import prepublish
@@ -196,13 +197,14 @@ try:
         def __init__(self,app = None, packconfig_spec = None):
             super(CeleryBackend,self).__init__(packconfig_spec)
             self.app = app or default_celeryapp
+            self.disable_sync = yaml.load(os.environ.get('PACKTIVITY_CELERY_DISABLE_SYNC','true'))
 
         def submit_callable(self,callable):
             self.app.set_current()
             return CeleryProxy(run_nullary.apply_async(kwargs = {'nullary': callable}))
 
         def result(self,resultproxy):
-            return resultproxy.proxy.get()
+            return resultproxy.proxy.get(disable_sync_subtasks = self.disable_sync)
 
         def ready(self,resultproxy):
             return resultproxy.proxy.ready()


### PR DESCRIPTION
this is necessary if you are running multiple independent celery instances
(such as in yadage service cluster)